### PR TITLE
Add checks to allow the bot owner to transfer/edit/delete tags.

### DIFF
--- a/leaf/extensions/tags.py
+++ b/leaf/extensions/tags.py
@@ -14,10 +14,12 @@ class TagsCog(commands.GroupCog, name="Tags", group_name="tags"):
     def __init__(self, bot: LeafBot) -> None:
         self.bot = bot
 
-    async def check_perms(self, tag_record,  interaction: discord.Interaction) -> bool:
-        return tag_record["owner_id"] == interaction.user.id \
-            or interaction.user.guild_permissions.manage_guild \
+    async def check_perms(self, tag_record, interaction: discord.Interaction) -> bool:
+        return (
+            tag_record["owner_id"] == interaction.user.id
+            or interaction.user.guild_permissions.manage_guild
             or await self.bot.is_owner(interaction.user)
+        )
 
     @app_commands.describe(
         starting_page="The page to start on.",
@@ -192,9 +194,7 @@ class TagsCog(commands.GroupCog, name="Tags", group_name="tags"):
                 )
                 return
 
-            if (
-                await self.check_perms(tag_record, interaction)
-            ):
+            if await self.check_perms(tag_record, interaction):
                 await interaction.response.send_message(
                     embed=discord.Embed(
                         description="Please reply to this message with your new tag content within 5 minutes.",
@@ -269,9 +269,7 @@ class TagsCog(commands.GroupCog, name="Tags", group_name="tags"):
                 )
                 return
 
-            if (
-                await self.check_perms(tag_record, interaction)
-            ):
+            if await self.check_perms(tag_record, interaction):
                 await self.bot.database.execute(
                     "UPDATE Tags SET deleted = true WHERE name = $1;", tag
                 )
@@ -358,9 +356,7 @@ class TagsCog(commands.GroupCog, name="Tags", group_name="tags"):
             )
 
             if tag_record:
-                if (
-                    await self.check_perms(tag_record, interaction)
-                ):
+                if await self.check_perms(tag_record, interaction):
                     if user.bot:
                         await interaction.response.send_message(
                             embed=discord.Embed(

--- a/leaf/extensions/tags.py
+++ b/leaf/extensions/tags.py
@@ -14,9 +14,11 @@ class TagsCog(commands.GroupCog, name="Tags", group_name="tags"):
     def __init__(self, bot: LeafBot) -> None:
         self.bot = bot
 
-    async def check_perms(self, tag_record, interaction: discord.Interaction) -> bool:
+    async def check_permissions(
+        self, tag_record: int, interaction: discord.Interaction
+    ) -> bool:
         return (
-            tag_record["owner_id"] == interaction.user.id
+            tag_record == interaction.user.id
             or interaction.user.guild_permissions.manage_guild
             or await self.bot.is_owner(interaction.user)
         )
@@ -194,7 +196,7 @@ class TagsCog(commands.GroupCog, name="Tags", group_name="tags"):
                 )
                 return
 
-            if await self.check_perms(tag_record, interaction):
+            if await self.check_permissions(tag_record["owner_id"], interaction):
                 await interaction.response.send_message(
                     embed=discord.Embed(
                         description="Please reply to this message with your new tag content within 5 minutes.",
@@ -269,7 +271,7 @@ class TagsCog(commands.GroupCog, name="Tags", group_name="tags"):
                 )
                 return
 
-            if await self.check_perms(tag_record, interaction):
+            if await self.check_permissions(tag_record["owner_id"], interaction):
                 await self.bot.database.execute(
                     "UPDATE Tags SET deleted = true WHERE name = $1;", tag
                 )
@@ -356,7 +358,7 @@ class TagsCog(commands.GroupCog, name="Tags", group_name="tags"):
             )
 
             if tag_record:
-                if await self.check_perms(tag_record, interaction):
+                if await self.check_permissions(tag_record["owner_id"], interaction):
                     if user.bot:
                         await interaction.response.send_message(
                             embed=discord.Embed(

--- a/leaf/extensions/tags.py
+++ b/leaf/extensions/tags.py
@@ -14,6 +14,11 @@ class TagsCog(commands.GroupCog, name="Tags", group_name="tags"):
     def __init__(self, bot: LeafBot) -> None:
         self.bot = bot
 
+    async def check_perms(self, tag_record,  interaction: discord.Interaction) -> bool:
+        return tag_record["owner_id"] == interaction.user.id \
+            or interaction.user.guild_permissions.manage_guild \
+            or await self.bot.is_owner(interaction.user)
+
     @app_commands.describe(
         starting_page="The page to start on.",
         silent="Whether the response should only be visible to you.",
@@ -188,8 +193,7 @@ class TagsCog(commands.GroupCog, name="Tags", group_name="tags"):
                 return
 
             if (
-                tag_record["owner_id"] == interaction.user.id
-                or interaction.user.guild_permissions.manage_guild
+                await self.check_perms(tag_record, interaction)
             ):
                 await interaction.response.send_message(
                     embed=discord.Embed(
@@ -266,8 +270,7 @@ class TagsCog(commands.GroupCog, name="Tags", group_name="tags"):
                 return
 
             if (
-                tag_record["owner_id"] == interaction.user.id
-                or interaction.user.guild_permissions.manage_guild
+                await self.check_perms(tag_record, interaction)
             ):
                 await self.bot.database.execute(
                     "UPDATE Tags SET deleted = true WHERE name = $1;", tag
@@ -356,8 +359,7 @@ class TagsCog(commands.GroupCog, name="Tags", group_name="tags"):
 
             if tag_record:
                 if (
-                    tag_record["owner_id"] == interaction.user.id
-                    or interaction.user.guild_permissions.manage_guild
+                    await self.check_perms(tag_record, interaction)
                 ):
                     if user.bot:
                         await interaction.response.send_message(


### PR DESCRIPTION
Included a check to allow the bot instance owner to edit/transfer/delete.

Additionally, moved this check to its own dedicated function to cut-down on duplicated code.

This closes #3.