### PR TITLE
Implemented a restore command.

### DIFF
--- a/migrations/0000-tags.sql
+++ b/migrations/0000-tags.sql
@@ -6,5 +6,7 @@ CREATE TABLE IF NOT EXISTS Tags (
     created_at TIMESTAMP NOT NULL DEFAULT (NOW() AT TIME ZONE 'utc'),
     last_edited_at TIMESTAMP NOT NULL DEFAULT (NOW() AT TIME ZONE 'utc'),
     uses INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (name, guild_id)
+    deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    PRIMARY KEY (name, guild_id, deleted)
 );
+

--- a/migrations/0000-tags.sql
+++ b/migrations/0000-tags.sql
@@ -6,6 +6,5 @@ CREATE TABLE IF NOT EXISTS Tags (
     created_at TIMESTAMP NOT NULL DEFAULT (NOW() AT TIME ZONE 'utc'),
     last_edited_at TIMESTAMP NOT NULL DEFAULT (NOW() AT TIME ZONE 'utc'),
     uses INTEGER NOT NULL DEFAULT 0,
-    deleted BOOLEAN NOT NULL DEFAULT FALSE,
     PRIMARY KEY (name, guild_id)
 );

--- a/migrations/0000-tags.sql
+++ b/migrations/0000-tags.sql
@@ -7,6 +7,5 @@ CREATE TABLE IF NOT EXISTS Tags (
     last_edited_at TIMESTAMP NOT NULL DEFAULT (NOW() AT TIME ZONE 'utc'),
     uses INTEGER NOT NULL DEFAULT 0,
     deleted BOOLEAN NOT NULL DEFAULT FALSE,
-    PRIMARY KEY (name, guild_id, deleted)
+    PRIMARY KEY (name, guild_id)
 );
-

--- a/migrations/0002-primary-update-tags.sql
+++ b/migrations/0002-primary-update-tags.sql
@@ -1,0 +1,3 @@
+ALTER TABLE Tags DROP CONSTRAINT Tags_pkey;
+
+ALTER TABLE Tags ADD CONSTRAINT Tags_pkey PRIMARY KEY (name, guild_id, deleted);

--- a/migrations/0002-primary-update-tags.sql
+++ b/migrations/0002-primary-update-tags.sql
@@ -1,3 +1,0 @@
-ALTER TABLE Tags DROP CONSTRAINT Tags_pkey;
-
-ALTER TABLE Tags ADD CONSTRAINT Tags_pkey PRIMARY KEY (name, guild_id, deleted);

--- a/migrations/0002-restorable-tags.sql
+++ b/migrations/0002-restorable-tags.sql
@@ -1,0 +1,3 @@
+ALTER TABLE Tags DROP CONSTRAINT Tags_pkey;
+
+ALTER TABLE Tags ADD CONSTRAINT Tags_pkey PRIMARY KEY (name, guild_id, deleted);


### PR DESCRIPTION
Requires a database upgrade to make deleted a primary key. Otherwise upon creating a new tag when a tag with the same name is marked as deleted, a UniqueViolationError is raised as there will be two primary keys with the same name/guild id.